### PR TITLE
Add batch directory pipeline with timing report

### DIFF
--- a/pipelines/orchestrator.py
+++ b/pipelines/orchestrator.py
@@ -33,7 +33,7 @@ spk = SpeakerIdentifier()
 asr = WhisperASR(model_name="medium", gpu=use_gpu)
 
 def process_segment(seg_path: str, t0: float, t1: float) -> dict:
-    """Process a single separated segment."""
+    """Process a single separated segment and return metrics."""
     logger.info(
         f"🔧 執行緒 {threading.get_ident()} 處理 ({t0:.2f}-{t1:.2f}) → {os.path.basename(seg_path)}"
     )
@@ -43,12 +43,14 @@ def process_segment(seg_path: str, t0: float, t1: float) -> dict:
     t_spk0 = time.perf_counter()
     speaker_id, name, dist = spk.process_audio_file(seg_path)
     t_spk1 = time.perf_counter()
-    logger.info(f"⏱ SpeakerID 耗時 {t_spk1 - t_spk0:.3f}s")
+    spk_time = t_spk1 - t_spk0
+    logger.info(f"⏱ SpeakerID 耗時 {spk_time:.3f}s")
 
     t_asr0 = time.perf_counter()
     text, conf, words = asr.transcribe(seg_path)
     t_asr1 = time.perf_counter()
-    logger.info(f"⏱ ASR 耗時 {t_asr1 - t_asr0:.3f}s")
+    asr_time = t_asr1 - t_asr0
+    logger.info(f"⏱ ASR 耗時 {asr_time:.3f}s")
 
     total = time.perf_counter() - start
     logger.info(f"⏱ segment 總耗時 {total:.3f}s")
@@ -61,6 +63,8 @@ def process_segment(seg_path: str, t0: float, t1: float) -> dict:
         "text": text,
         "confidence": round(conf, 2),
         "words": words,
+        "spk_time": spk_time,
+        "asr_time": asr_time,
     }
 
 
@@ -81,6 +85,7 @@ def run_pipeline_file(raw_wav: str, max_workers: int = 3):
     total_start = time.perf_counter()
 
     waveform, sr = torchaudio.load(raw_wav)
+    audio_len = waveform.shape[1] / sr
     out_dir = pathlib.Path("work_output") / dt.now().strftime("%Y%m%d_%H%M%S")
     out_dir.mkdir(parents=True, exist_ok=True)
 
@@ -94,6 +99,8 @@ def run_pipeline_file(raw_wav: str, max_workers: int = 3):
     logger.info(f"🔄 處理 {len(segments)} 段... (max_workers={max_workers})")
     with ThreadPoolExecutor(max_workers=max_workers) as ex:
         bundle = [r for r in ex.map(lambda s: process_segment(*s), segments) if r]
+    spk_time = sum(s.get("spk_time", 0.0) for s in bundle)
+    asr_time = sum(s.get("asr_time", 0.0) for s in bundle)
 
     # 3) 輸出結果
     bundle.sort(key=lambda x: x["start"])
@@ -104,8 +111,41 @@ def run_pipeline_file(raw_wav: str, max_workers: int = 3):
         json.dump({"segments": bundle}, f, ensure_ascii=False, indent=2)
 
     total_end = time.perf_counter()
-    logger.info(f"✅ Pipeline finished → {json_path} (總耗時 {total_end - total_start:.3f}s)")
-    return bundle, pretty_bundle
+    total_time = total_end - total_start
+    logger.info(f"✅ Pipeline finished → {json_path} (總耗時 {total_time:.3f}s)")
+
+    stats = {
+        "length": audio_len,
+        "total": total_time,
+        "separate": sep_end - sep_start,
+        "speaker": spk_time,
+        "asr": asr_time,
+    }
+
+    return bundle, pretty_bundle, stats
+
+
+def run_pipeline_dir(directory: str, max_workers: int = 3, out_path: str = "summary.tsv"):
+    """Run pipeline on every wav file in a directory and save summary."""
+    dir_path = pathlib.Path(directory)
+    wav_files = sorted(dir_path.glob("*.wav"))
+    results = []
+    for idx, wav in enumerate(wav_files, start=1):
+        logger.info(f"===== Processing {wav.name} ({idx}/{len(wav_files)}) =====")
+        _, _, stats = run_pipeline_file(str(wav), max_workers)
+        results.append((idx, stats))
+
+    if results:
+        with open(out_path, "w", encoding="utf-8") as f:
+            f.write("編號\t音檔長度(s)\t總耗時(s)\t分離耗時(s)\tSpeakerID耗時(s)\tASR耗時(s)\n")
+            for idx, st in results:
+                f.write(
+                    f"{idx}\t{st['length']:.2f}\t{st['total']:.2f}\t{st['separate']:.2f}\t{st['speaker']:.2f}\t{st['asr']:.2f}\n"
+                )
+        logger.info(f"📄 Summary saved to {out_path}")
+    else:
+        logger.warning("No wav files found in directory")
+    return results
 
 # Backwards compatible name
 run_pipeline = run_pipeline_file
@@ -119,10 +159,17 @@ def main():
     p_file.add_argument("path")
     p_file.add_argument("--workers", type=int, default=4)
 
+    p_dir = sub.add_parser("dir", help="process all wav files in a directory")
+    p_dir.add_argument("path")
+    p_dir.add_argument("--workers", type=int, default=4)
+    p_dir.add_argument("--out", default="summary.tsv")
+
     args = parser.parse_args()
 
     if args.mode == "file":
         run_pipeline_file(args.path, args.workers)
+    elif args.mode == "dir":
+        run_pipeline_dir(args.path, args.workers, args.out)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- expand `WhisperASR` with `transcribe_dir` helper
- extend orchestrator with batch directory mode
- collect timing metrics for each phase and save TSV summary

## Testing
- `python -m py_compile pipelines/orchestrator.py modules/asr/whisper_asr.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'modules', 'weaviate')*

------
https://chatgpt.com/codex/tasks/task_e_68638de35884832a9e2c1c90ae0c4a5e