### PR TITLE
Add directory transcription endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,23 @@ print(result["pretty"])  # 人類可讀格式
 print(result["segments"])  # 機器可讀格式(含時間戳)
 ```
 
+### 2. 資料夾批次轉錄 API
+
+可以一次處理數個音檔。僅需傳入路徑或上傳 ZIP 檔就可以啟動。
+
+```python
+import requests
+
+# 傳入路徑
+resp = requests.post("http://localhost:8000/transcribe_dir", data={"path": "/path/to/wavs"})
+print(resp.json()["summary_tsv"])
+
+# 以 ZIP 檔上傳
+with open("audios.zip", "rb") as f:
+    resp = requests.post("http://localhost:8000/transcribe_dir", files={"zip_file": f})
+print(resp.json()["summary_tsv"])
+```
+
 ## 其他說明
 
 - **模型快取**：ASR 與分離模型會自動下載至 `models/` 相關資料夾。


### PR DESCRIPTION
## Summary
- add `run_pipeline_dir` to process a folder of audio files
- support `/transcribe_dir` endpoint accepting a path or ZIP
- document how to use the new endpoint

## Testing
- `python -m py_compile services/api.py pipelines/orchestrator.py`

------
https://chatgpt.com/codex/tasks/task_e_6863943ff0a8832a87c5d729c46b6b54