### PR TITLE
Add ASR metrics report

### DIFF
--- a/modules/asr/__init__.py
+++ b/modules/asr/__init__.py
@@ -2,11 +2,13 @@
 """語音辨識封裝，提供 Whisper ASR 模型與輔助函式。"""
 
 from .asr_model import load_model
-from .text_utils import merge_char_to_word
+from .text_utils import merge_char_to_word, compute_wer, compute_cer
 from .whisper_asr import WhisperASR
 
 __all__ = [
     "load_model",
     "merge_char_to_word",
     "WhisperASR",
+    "compute_wer",
+    "compute_cer",
 ]


### PR DESCRIPTION
## Summary
- export `compute_wer` and `compute_cer` utilities
- implement WER/CER helpers in `text_utils`
- compute average confidence, WER and CER in pipeline
- generate `asr_report.tsv` when running directory pipeline

## Testing
- `python -m py_compile modules/asr/text_utils.py modules/asr/__init__.py pipelines/orchestrator.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jieba_fast')*

------
https://chatgpt.com/codex/tasks/task_e_686e45082230832aacd4bbc774f350dc